### PR TITLE
Sets the Ansible Galaxy role_name Variable

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: django
   author: Ona Engineering
   company: Ona Systems Inc
   description: Install and configure Django

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -40,6 +40,7 @@
       - celery
       - uwsgi
       - 'redis==2.10.6'
+      - 'django==1.11'
     django_top_python_statements:
       - import os
       - from decimal import Decimal


### PR DESCRIPTION
We need to set the variable because Ansible Galaxy no longer
applies a regex on the repository name to remove 'ansible-' for
the role name. Therefore, this role, on Ansible Galaxy will be called
"ansible_django" instead of just "django".

Signed-off-by: Jason Rogena <jason@rogena.me>