### PR TITLE
Adds Support for Setting Multiple Environment Variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ django_venv_path: "{{ django_system_user_home }}/.virtualenvs/{{ django_system_u
 django_log_path: "/var/log/{{ django_service_name }}"
 django_pid_file: "{{ django_pid_socks_dir }}/{{ django_service_name }}.pid"
 django_proxy_read_timeout: "300s"
+django_environment_script_name: environment.sh
+django_environment_vars: []
 
 # Python packages
 django_recreate_virtual_env: False

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -151,3 +151,11 @@
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     mode: 0644
+
+- name: Copy the environment script
+  template:
+    src: "django_checkout_path/django_environment_script_name.j2"
+    dest: "{{ django_checkout_path }}/{{ django_environment_script_name }}"
+    owner: "{{ django_system_user }}"
+    group: "{{ django_system_group }}"
+    mode: 0750

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,14 @@
 ---
+- name: Copy the service environment file
+  template:
+    src: "etc/default/django_service_name.j2"
+    dest: "/etc/default/{{ django_service_name }}"
+    mode: 0640
+    owner: "{{ django_system_user }}"
+    group: "{{ django_system_group }}"
+  notify:
+    - restart_service
+
 - name: Copy upstart scripts
   template:
     src: "etc/systemd/django.service.j2"

--- a/templates/django_checkout_path/django_environment_script_name.j2
+++ b/templates/django_checkout_path/django_environment_script_name.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export DJANGO_SETTINGS_MODULE="{{ django_settings_module }}"
+{% for cur_item in django_environment_vars %}
+{% for var_name,var_value in cur_item.items() %}
+export {{ var_name }}={{ var_value }}
+{% endfor %}
+{% endfor %}

--- a/templates/etc/default/django_service_name.j2
+++ b/templates/etc/default/django_service_name.j2
@@ -1,0 +1,6 @@
+DJANGO_SETTINGS_MODULE="{{ django_settings_module }}"
+{% for cur_item in django_environment_vars %}
+{% for var_name,var_value in cur_item.items() %}
+{{ var_name }}={{ var_value }}
+{% endfor %}
+{% endfor %}

--- a/templates/etc/systemd/django.service.j2
+++ b/templates/etc/systemd/django.service.j2
@@ -9,7 +9,8 @@ RuntimeDirectory={{ django_service_name }}
 WorkingDirectory={{ django_codebase_path }}
 User={{ django_system_user }}
 Group={{ django_service_group }}
-ExecStart={{ django_venv_path }}/bin/uwsgi --ini {{ django_codebase_path }}/uwsgi.ini --env DJANGO_SETTINGS_MODULE={{ django_settings_module }}
+EnvironmentFile=-/etc/default/{{ django_service_name }}
+ExecStart={{ django_venv_path }}/bin/uwsgi --ini {{ django_codebase_path }}/uwsgi.ini
 
 
 [Install]


### PR DESCRIPTION
When deploying a Django app, you might want to set multiple environment
variables. This pull request adds two files that set environment variables; an
environment file referenced in the systemd unit file for the service and
an environment script that should be run before running the uWSGI
binary.

Signed-off-by: Jason Rogena <jason@rogena.me>