### PR TITLE
Set the Group Ownership for Created Directories

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
   file:
     state: directory
     owner: "{{ django_system_user }}"
-    group: www-data
+    group: "{{ django_system_group }}"
     path: "{{ item }}"
   when:
     - item is defined


### PR DESCRIPTION
Set the group ownership for created directories to the value of
django_system_group, instead of the hardcoded "www-data".

Signed-off-by: Jason Rogena <jason@rogena.me>