### PR TITLE
Make Sure the Local Settings Directory is Present

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -162,6 +162,14 @@
     virtualenv_python: "{{ django_python_version }}"
   become_user: "{{ django_system_user }}"
 
+- name: Make sure the local settings directory is present
+  file:
+    path: "{{ django_local_settings_path | dirname }}"
+    state: directory
+    owner: "{{ django_system_user }}"
+    group: "{{ django_system_group }}"
+    mode: 0750
+
 - name: Copy local settings from template
   template:
     src: "{{ django_settings_template_path }}"


### PR DESCRIPTION
Before copying over the local settings .py file, make sure the directory
in the destination exists. Do this because, for some Django apps, the
directory isn't present in the codebase.

Signed-off-by: Jason Rogena <jason@rogena.me>