### PR TITLE
Minor fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,11 +14,13 @@ django_copy_key_from_file: false
 
 # system-wide dependencies
 django_python_source_version: "3.6"
-django_python_version: "python3.6"  # or python3.x
+django_python_version: "python3.6" # or python3.x
+django_python_packages:
+  - python3.6
+  - python3.6-dev
 django_system_wide_dependencies:
   - build-essential
   - git
-  - python3.6-dev
 
 # service
 django_service_name: "{{ django_system_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ django_system_user_home: "/home/{{ django_system_user }}"
 # git
 django_git_url:
 django_git_version: "master"
-django_git_key:
+django_git_key_content:
 django_git_key_ssh_file:
 django_git_key_filename: "id_ed25519"
 django_remove_git_key: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ django_git_key_ssh_file:
 django_git_key_filename: "id_ed25519"
 django_remove_git_key: True
 django_copy_key_from_file: false
+django_optional_git_packages:
 
 # system-wide dependencies
 django_python_source_version: "3.6"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,9 +10,11 @@ galaxy_info:
       - all
 
 dependencies:
- - role: ANXS.python
+ - role: DavisRayM.python
    become: true
    become_user: "root"
    python_source_version: "{{ django_python_source_version }}"
+   python_packages: "{{ django_python_packages }}"
+   python_apt_ppa: "{{ django_apt_python_ppa }}"
    tags:
     - python

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 ---
-- name: ANXS.python
-  version: v2.0.0
+- src: https://github.com/DavisRayM/python
+  name: DavisRayM.python
+  scm: git
+  version: 0c10923ef95aaa97ccdf246fce1898330061807a

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -83,17 +83,6 @@
     - django_git_key_content is defined or django_git_key_ssh_file is defined
     - django_git_key_content is not none or django_git_key_ssh_file is not none
 
-- name: Remove Git Key
-  file:
-    state: absent
-    path: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
-  become: True
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_git_key_content is defined or django_git_key_ssh_file is defined
-    - django_git_key_content is not none or django_git_key_ssh_file is not none
-    - django_remove_git_key == True
-
 - name: Git clone without key
   git:
     accept_hostkey: "yes"
@@ -154,6 +143,28 @@
     virtualenv: "{{ django_venv_path }}"
     virtualenv_python: "{{ django_python_version }}"
   become_user: "{{ django_system_user }}"
+
+- name: Install packages from Github
+  become: True
+  become_user: "{{ django_system_user }}"
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ django_venv_path }}"
+    virtualenv_python: "{{ django_python_version }}"
+    extra_args: "-e"
+  with_items: "{{ django_optional_git_packages }}"
+  when: django_optional_git_packages is defined and django_use_regular_old_pip
+
+- name: Remove Git Key
+  file:
+    state: absent
+    path: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
+  become: True
+  become_user: "{{ django_system_user }}"
+  when:
+    - django_git_key_content is defined or django_git_key_ssh_file is defined
+    - django_git_key_content is not none or django_git_key_ssh_file is not none
+    - django_remove_git_key == True
 
 - name: Make sure the local settings directory is present
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,14 +56,14 @@
 
 - name: Copy git key from string
   copy:
-    content: "{{ django_git_key }}"
+    content: "{{ django_git_key_content }}"
     dest: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
     owner: "{{ django_system_user }}"
     mode: 0600
   no_log: False
   when:
-    - django_git_key is defined
-    - django_git_key is not none
+    - django_git_key_content is defined
+    - django_git_key_content is not none
 
 - name: Copy git key from file
   copy:
@@ -88,8 +88,8 @@
   become: True
   become_user: "{{ django_system_user }}"
   when:
-    - django_git_key is defined or django_git_key_ssh_file is defined
-    - django_git_key is not none or django_git_key_ssh_file is not none
+    - django_git_key_content is defined or django_git_key_ssh_file is defined
+    - django_git_key_content is not none or django_git_key_ssh_file is not none
 
 - name: Remove Git Key
   file:
@@ -98,8 +98,8 @@
   become: True
   become_user: "{{ django_system_user }}"
   when:
-    - django_git_key is defined
-    - django_git_key is not none
+    - django_git_key_content is defined or django_git_key_ssh_file is defined
+    - django_git_key_content is not none or django_git_key_ssh_file is not none
     - django_remove_git_key == True
 
 - name: Git clone without key

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -83,6 +83,15 @@
     - django_git_key_content is defined or django_git_key_ssh_file is defined
     - django_git_key_content is not none or django_git_key_ssh_file is not none
 
+- name: Ensure Github is in the known hosts file
+  known_hosts:
+    path: "{{ django_system_user_home }}/.ssh/known_hosts"
+    name: github.com
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+  when:
+    - django_git_key_content is defined or django_git_key_ssh_file is defined
+    - django_git_key_content is not none or django_git_key_ssh_file is not none
+
 - name: Git clone without key
   git:
     accept_hostkey: "yes"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,14 +11,6 @@
     append: yes
     createhome: yes
 
-- name: Add Python PPA
-  apt_repository:
-    repo: "{{ django_apt_python_ppa }}"
-    state: present
-  become: true
-  become_user: root
-  when: django_apt_python_ppa is defined and django_apt_python_ppa != ""
-
 - name: Update apt cache
   apt:
     update_cache: "yes"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,7 +67,7 @@
 
 - name: Copy git key from file
   copy:
-    src: "{{ django_git_key }}"
+    src: "{{ django_git_key_ssh_file }}"
     dest: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
     owner: "{{ django_system_user }}"
     mode: 0600
@@ -88,8 +88,8 @@
   become: True
   become_user: "{{ django_system_user }}"
   when:
-    - django_git_key is defined
-    - django_git_key is not none
+    - django_git_key is defined or django_git_key_ssh_file is defined
+    - django_git_key is not none or django_git_key_ssh_file is not none
 
 - name: Remove Git Key
   file:
@@ -113,7 +113,8 @@
   become: True
   become_user: "{{ django_system_user }}"
   when:
-    - django_git_key is not defined or django_git_key is none
+    - django_git_key_content is not defined or django_git_key_content is none
+    - django_git_key_ssh_file is not defined or django_git_key_ssh_file is none
 
 - name: Upgrade pip to latest version
   pip:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -28,7 +28,7 @@
     django_git_url: "https://github.com/moshthepitt/picha"
     django_git_version: "master"
     django_celery_app: "picha"
-    django_python_source_version: "2.7"
+    django_python_source_version: "3.6"
     django_python_version: "python3.6"
     django_enable_celery: True
     django_local_settings_path: "{{ django_checkout_path }}/picha/local_settings.py"


### PR DESCRIPTION
- Switch from using `ANXS.python` to [`DavisRayM.python`](https://github.com/DavisRayM/python)
- Fix an issue where the git key file would be treated as the git key content
- Add a task that optionally installs packages from github using pip

## Reviewer Note

Decided to diverge from the ANXS.python role since it has a few weird tasks I wasn't too sure how to handle on the role.

1. The role uses `/usr/bin/python` to install python. _This is not configurable. Specifying the `python_source_version` doesn't seem to change anything... As far as I could tell._ In most cases if the server has both python2 and python3 the role will install pip for python2 unless `/usr/bin/python` is linked to python3.

2. It doesn't specify the executable for pip tasks to the `python_pip_location` variable it has. This is usually fine but in servers where python3 is present ansible defaults to using pip3 which might not be installed and thus this task fails. This can be fixed by changing the `ansible_python_interpreter` to use `/usr/bin/python` but then it just installs pip for python2 and the packages for python2 also....

_TL;DR main issue with the role is that it doesn't install python3 and I don't believe it's possible to configure it to do so as it is_

I think it'll be better to maintain our own fork of the ansible role as it doesn't seem to be actively maintained(_Last update was in November 2018_). Ideally we wouldn't use the repo in my account but move it to the `onaio` organization if possible.