### PR TITLE
Add task to install dependency packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,7 @@ django_pip_paths:
 django_pip_packages:
   - celery
   - uwsgi
+django_pip_packages_extra_args:
 
 # Django
 django_local_settings_path:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,10 @@ django_recreate_virtual_env: false
 ## pipenv
 django_use_pipenv: false
 
+## dependency pip packages
+## packages you'd want to install before install packages in the requirement's file
+django_dependency_pip_packages: []
+
 ## pip
 django_use_regular_old_pip: true
 django_pip_paths:

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -16,19 +16,19 @@
   template:
     src: templates/etc/default/celeryd.j2
     dest: /etc/default/celeryd-{{ django_system_user }}
-    mode: 0644
+    mode: "0644"
 
 - name: Copy celerybeat default script
   template:
     src: templates/etc/default/celerybeat.j2
     dest: /etc/default/celerybeat-{{ django_system_user }}
-    mode: 0644
+    mode: "0644"
 
 - name: Copy celeryd upstart script
   template:
     src: "etc/systemd/celeryd.service.j2"
     dest: "/etc/systemd/system/{{ django_celeryd_service_name }}.service"
-    mode: 0644
+    mode: "0644"
   notify:
     - restart_celery
 
@@ -36,6 +36,6 @@
   template:
     src: "etc/systemd/celerybeat.service.j2"
     dest: "/etc/systemd/system/{{ django_celerybeat_service_name }}.service"
-    mode: 0644
+    mode: "0644"
   notify:
     - restart_celery

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -111,6 +111,15 @@
     name: pip
     state: present
 
+- name: Install dependency Python packages using pip
+  pip:
+    name: "{{ django_dependency_pip_packages }}"
+    state: present
+    virtualenv: "{{ django_venv_path }}"
+    virtualenv_python: "{{ django_python_version }}"
+  become: true
+  become_user: "{{ django_system_user }}"
+
 - name: Install Python packages using pip
   pip:
     state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -163,6 +163,7 @@
     state: present
     virtualenv: "{{ django_venv_path }}"
     virtualenv_python: "{{ django_python_version }}"
+    extra_args: "{{ django_pip_packages_extra_args }}"
   become: true
   become_user: "{{ django_system_user }}"
 

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -3,7 +3,7 @@
   template:
     src: "etc/default/django_service_name.j2"
     dest: "/etc/default/{{ django_service_name }}"
-    mode: 0640
+    mode: "0640"
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
   notify:
@@ -13,7 +13,7 @@
   template:
     src: "etc/systemd/django.service.j2"
     dest: /etc/systemd/system/{{ item }}
-    mode: 0644
+    mode: "0644"
   notify:
     - restart_service
   with_items:


### PR DESCRIPTION
This allows someone to lockdown package versions before installing other
packages using a requirements file. E.g. installing `setuptools==45`
because `markupsafe==1.0` cannot work with `setuptools>45`.