### PR TITLE
support for uv mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+__pycache__
 *.retry
 *.log
+.ansible
 .vagrant/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ django_settings:
     }
 ```
 
+## uv (Astral) install mode
+
+The role can install Python dependencies via [uv](https://docs.astral.sh/uv/) instead of pip, pipenv, or poetry. This mode requires the consuming project to have a `pyproject.toml` and `uv.lock` checked in.
+
+Enable it by setting:
+
+```yml
+django_use_uv: true
+django_use_regular_old_pip: false
+django_use_pipenv: false
+django_use_poetry: false
+```
+
+When enabled, the role:
+
+1. Installs the `uv` binary to `/usr/local/bin/uv` on the host (idempotent — re-runs are no-ops).
+2. Runs `uv sync --frozen --no-dev --python {{ django_python_version }}` against `{{ django_uv_project_dir }}` (defaults to `{{ django_checkout_path }}`), with `UV_PROJECT_ENVIRONMENT={{ django_venv_path }}` so the resulting venv lands at the path the rest of the role (uwsgi, systemd units) expects.
+3. Continues to install `django_pip_packages` (uwsgi, celery, etc.) into the same venv via the role's existing pip step — no change there.
+
+Tunables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `django_use_uv` | `false` | Enable the uv install mode. |
+| `django_uv_version` | `"latest"` | Version installed via the astral.sh installer. Pin to e.g. `"0.6.10"` for reproducibility. |
+| `django_uv_project_dir` | `"{{ django_checkout_path }}"` | Directory containing `pyproject.toml` + `uv.lock`. |
+| `django_uv_sync_args` | `"--frozen --no-dev"` | Flags passed to `uv sync`. |
+
 ## Testing
 
 This project utilizes molecule for testing, the molecule tool can be installed by running `pip install 'molecule[docker]'` after which tests can run with `molecule test --all`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,9 @@ django_use_pipenv: false
 ## uv (Astral)
 django_use_uv: false
 # Version of uv to install. Use "latest" or a pinned release like "0.6.10".
-# Pinning makes the install task's `creates:` idempotency check meaningful.
+# When pinned, bumping this value triggers a re-install on the next run
+# (the install task probes `uv --version` and compares to this string).
+# When set to "latest" the install task re-runs every play.
 django_uv_version: "latest"
 # Directory containing pyproject.toml + uv.lock. Defaults to the checkout root.
 django_uv_project_dir: "{{ django_checkout_path }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,16 @@ django_setuptools_version:
 ## pipenv
 django_use_pipenv: false
 
+## uv (Astral)
+django_use_uv: false
+# Version of uv to install. Use "latest" or a pinned release like "0.6.10".
+# Pinning makes the install task's `creates:` idempotency check meaningful.
+django_uv_version: "latest"
+# Directory containing pyproject.toml + uv.lock. Defaults to the checkout root.
+django_uv_project_dir: "{{ django_checkout_path }}"
+# Flags passed to `uv sync`. Default mirrors prod intent: locked, prod-only.
+django_uv_sync_args: "--frozen --no-dev"
+
 ## dependency pip packages
 ## packages you'd want to install before install packages in the requirement's file
 django_dependency_pip_packages: []

--- a/molecule/uv/converge.yml
+++ b/molecule/uv/converge.yml
@@ -1,0 +1,57 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: Update apt cache.
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 600
+      when: ansible_os_family == 'Debian'
+
+    - name: Wait for systemd to complete initialization.  # noqa: command-instead-of-module
+      ansible.builtin.command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
+  roles:
+    - role: onaio.django
+      django_python_version: "python3.12"
+      django_system_user: "sample_uv_app"
+      django_system_user_home: "/home/{{ django_system_user }}"
+      django_recreate_virtual_env: false
+      django_manage_services: false
+      django_codebase_path: "{{ django_system_user_home }}/app"
+      django_versioned_path: "{{ django_codebase_path }}-versioned"
+      django_checkout_path: "{{ django_versioned_path }}/{{ ansible_date_time['epoch'] }}"
+      # Pull from the local fixture repo seeded in prepare.yml.
+      django_git_url: "/opt/sample-uv-project"
+      django_git_version: "main"
+      django_system_wide_dependencies:
+        - build-essential
+        - git
+      # uv mode
+      django_use_uv: true
+      django_use_regular_old_pip: false
+      django_use_pipenv: false
+      django_use_poetry: false
+      # Verify that the role's mode-agnostic extras-pip step still installs
+      # into the uv-created venv. tally-ho uses this for uwsgi; we use a
+      # tiny pure-python package here to keep the converge fast.
+      django_pip_packages:
+        - click
+      # Disable celery to keep the test surface minimal.
+      django_enable_celery: false
+      django_local_settings_path: "{{ django_checkout_path }}/sample/local_settings.py"
+      django_settings_module: "sample.settings"
+      django_wsgi_module: "sample.wsgi:application"
+      django_init_commands:
+      django_top_python_statements:
+        - import os
+      django_bottom_python_statements:
+        - SECRET_KEY = "molecule-fixture-not-a-real-secret"

--- a/molecule/uv/molecule.yml
+++ b/molecule/uv/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+provisioner:
+  name: ansible
+scenario:
+  name: uv
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy
+verifier:
+  name: testinfra

--- a/molecule/uv/prepare.yml
+++ b/molecule/uv/prepare.yml
@@ -1,0 +1,62 @@
+---
+# Stage the sample uv project as a local git repo on the molecule host so
+# the role's git-clone step has a reachable file:// URL to pull from. This
+# avoids depending on an external public repo for the test.
+- name: Prepare sample uv project on the molecule host
+  hosts: all
+  become: true
+  vars:
+    sample_repo_path: /opt/sample-uv-project
+    fixture_src: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/tests/fixtures/sample-uv-project"
+  tasks:
+    - name: Install git
+      ansible.builtin.apt:
+        name: git
+        state: present
+        update_cache: true
+        cache_valid_time: 600
+
+    - name: Ensure sample project directory exists
+      ansible.builtin.file:
+        path: "{{ sample_repo_path }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy fixture files into the sample project directory
+      ansible.builtin.copy:
+        src: "{{ fixture_src }}/"
+        dest: "{{ sample_repo_path }}/"
+        mode: preserve
+
+    - name: Initialize git repo for the fixture
+      ansible.builtin.shell: |
+        set -eo pipefail
+        cd "{{ sample_repo_path }}"
+        if [ ! -d .git ]; then
+          git -c init.defaultBranch=main init -q
+          git -c user.email=molecule@example.com \
+              -c user.name=molecule \
+              -c commit.gpgsign=false \
+              add -A
+          git -c user.email=molecule@example.com \
+              -c user.name=molecule \
+              -c commit.gpgsign=false \
+              commit -q -m "fixture"
+        fi
+      args:
+        executable: /bin/bash
+      changed_when: true
+
+    # The role's git task runs as the django system user, but the fixture
+    # repo above was created as root. Modern git refuses to operate on
+    # repos with mismatched ownership; mark the fixture path as safe
+    # system-wide so the role's clone doesn't trip on it.
+    # Use `git config` directly: ansible.builtin has no git_config module,
+    # and pulling in community.general just for this molecule-fixture
+    # helper isn't worth the collection dep + CI lint plumbing.
+    # safe.directory='*' trusts every repo system-wide; safe inside a
+    # disposable molecule container, would not be acceptable in prod.
+    - name: Mark all directories as safe for git (molecule fixture only)  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: git config --system --add safe.directory '*'
+      changed_when: true

--- a/molecule/uv/tests/test_uv.py
+++ b/molecule/uv/tests/test_uv.py
@@ -1,0 +1,44 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_uv_binary_installed(host):
+    uv = host.file('/usr/local/bin/uv')
+    assert uv.exists
+    assert uv.mode & 0o111  # executable
+
+    cmd = host.run('/usr/local/bin/uv --version')
+    assert cmd.rc == 0
+    assert 'uv' in cmd.stdout
+
+
+def test_venv_python_present(host):
+    venv_python = host.file(
+        '/home/sample_uv_app/.virtualenvs/sample_uv_app/bin/python'
+    )
+    assert venv_python.exists
+
+
+def test_django_admin_in_venv(host):
+    django_admin = host.file(
+        '/home/sample_uv_app/.virtualenvs/sample_uv_app/bin/django-admin'
+    )
+    assert django_admin.exists
+    assert django_admin.mode & 0o111
+
+
+def test_extras_pip_packages_installed_into_uv_venv(host):
+    # The role's mode-agnostic extras-pip step (django_pip_packages) must
+    # install into the same venv uv created. tally-ho relies on this for
+    # uwsgi; the converge sets django_pip_packages to ["click"].
+    pip_show = host.run(
+        '/home/sample_uv_app/.virtualenvs/sample_uv_app/bin/python '
+        '-m pip show click'
+    )
+    assert pip_show.rc == 0
+    assert 'Name: click' in pip_show.stdout

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -251,11 +251,11 @@
       uv pip install
       --python {{ django_venv_path }}/bin/python
       pip
+    creates: "{{ django_venv_path }}/bin/pip"
   environment:
     UV_LINK_MODE: copy
   become: true
   become_user: "{{ django_system_user }}"
-  changed_when: true
   when:
     - django_use_uv| bool
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -225,6 +225,40 @@
   when:
     - django_use_pipenv| bool
 
+- name: Install Python packages using uv sync
+  ansible.builtin.command:
+    cmd: >-
+      uv sync
+      {{ django_uv_sync_args }}
+      --python {{ django_python_version }}
+    chdir: "{{ django_uv_project_dir }}"
+  environment:
+    UV_PROJECT_ENVIRONMENT: "{{ django_venv_path }}"
+    UV_LINK_MODE: copy
+    UV_COMPILE_BYTECODE: "1"
+  become: true
+  become_user: "{{ django_system_user }}"
+  changed_when: true
+  when:
+    - django_use_uv| bool
+
+# uv sync does not install pip into the venv (uv manages packages
+# directly). Bootstrap pip so the mode-agnostic extras-pip step below
+# (django_pip_packages: uwsgi, celery, ...) has a working pip binary.
+- name: Bootstrap pip into the uv-managed venv
+  ansible.builtin.command:
+    cmd: >-
+      uv pip install
+      --python {{ django_venv_path }}/bin/python
+      pip
+  environment:
+    UV_LINK_MODE: copy
+  become: true
+  become_user: "{{ django_system_user }}"
+  changed_when: true
+  when:
+    - django_use_uv| bool
+
 - name: Install other python packages using pip
   ansible.builtin.pip:
     name: "{{ django_pip_packages }}"

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -33,3 +33,36 @@
   become: true
   become_user: root
   when: django_install_virtualenv
+
+- name: Install uv install-script prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+    state: present
+    update_cache: true
+    cache_valid_time: 600
+  become: true
+  become_user: root
+  when: django_use_uv
+
+- name: Install uv (Astral)
+  vars:
+    # "latest" → unpinned URL (astral.sh/uv/install.sh), which the
+    # installer treats as latest. Anything else → pinned URL with the
+    # version segment (astral.sh/uv/<x.y.z>/install.sh).
+    _uv_installer_url: >-
+      {{
+        'https://astral.sh/uv/install.sh'
+        if django_uv_version == 'latest'
+        else 'https://astral.sh/uv/' ~ django_uv_version ~ '/install.sh'
+      }}
+  ansible.builtin.shell: |
+    set -eo pipefail
+    curl -LsSf {{ _uv_installer_url }} | env UV_INSTALL_DIR=/usr/local/bin sh
+  args:
+    executable: /bin/bash
+    creates: /usr/local/bin/uv
+  become: true
+  become_user: root
+  when: django_use_uv

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -46,6 +46,15 @@
   become_user: root
   when: django_use_uv
 
+- name: Probe installed uv version
+  ansible.builtin.command: /usr/local/bin/uv --version
+  register: _uv_installed
+  failed_when: false
+  changed_when: false
+  become: true
+  become_user: root
+  when: django_use_uv
+
 - name: Install uv (Astral)
   vars:
     # "latest" → unpinned URL (astral.sh/uv/install.sh), which the
@@ -57,12 +66,24 @@
         if django_uv_version == 'latest'
         else 'https://astral.sh/uv/' ~ django_uv_version ~ '/install.sh'
       }}
+    # `uv --version` prints "uv X.Y.Z" on a single line. Split + last
+    # extracts the exact version string for an equality compare —
+    # avoids the substring footgun where "0.6.1" matches "0.6.10".
+    _uv_installed_version: >-
+      {{ (_uv_installed.stdout | default('')).split() | last
+         if (_uv_installed.stdout | default('') | length) > 0 else '' }}
   ansible.builtin.shell: |
     set -eo pipefail
     curl -LsSf {{ _uv_installer_url }} | env UV_INSTALL_DIR=/usr/local/bin sh
   args:
     executable: /bin/bash
-    creates: /usr/local/bin/uv
   become: true
   become_user: root
-  when: django_use_uv
+  # The `when:` already gates execution on "installer would change
+  # something", so any time this task fires it really did install.
+  changed_when: true
+  when:
+    - django_use_uv
+    - _uv_installed.rc != 0
+      or django_uv_version == 'latest'
+      or _uv_installed_version != django_uv_version

--- a/tests/fixtures/sample-uv-project/manage.py
+++ b/tests/fixtures/sample-uv-project/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sample.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample-uv-project/pyproject.toml
+++ b/tests/fixtures/sample-uv-project/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "sample-uv-project"
+version = "0.1.0"
+description = "Minimal Django app used by the molecule uv scenario"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "django>=5,<6",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["sample"]

--- a/tests/fixtures/sample-uv-project/sample/settings.py
+++ b/tests/fixtures/sample-uv-project/sample/settings.py
@@ -1,0 +1,11 @@
+SECRET_KEY = "molecule-fixture-not-a-real-secret"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+INSTALLED_APPS = ["django.contrib.contenttypes", "django.contrib.auth"]
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+USE_TZ = True

--- a/tests/fixtures/sample-uv-project/uv.lock
+++ b/tests/fixtures/sample-uv-project/uv.lock
@@ -1,0 +1,55 @@
+version = 1
+revision = 1
+requires-python = "==3.12.*"
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345 },
+]
+
+[[package]]
+name = "django"
+version = "5.2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982 },
+]
+
+[[package]]
+name = "sample-uv-project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "django" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "django", specifier = ">=5,<6" }]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321 },
+]


### PR DESCRIPTION
## Summary

Adds an opt-in `django_use_uv` install mode alongside the existing `django_use_regular_old_pip` / `django_use_pipenv` / `django_use_poetry` modes. The mode reads `pyproject.toml` + `uv.lock` from the project checkout and runs `uv sync --frozen --no-dev` into the same venv path the rest of the role expects (`django_venv_path`), so uwsgi systemd units, the wsgi config, etc. don't change.

**Off by default — no behavior change for existing consumers.**

## Why

Driven by onaio/tally-ho#561, which migrated tally-ho off `requirements/*.pip` to a `pyproject.toml` + `uv.lock` workflow. Without this mode, the next deploy via onaio/ansible-tally-ho would fail at the `pip install -r requirements/dev.pip` step (the file no longer exists upstream). The downstream wiring lives in onaio/ansible-tally-ho#25.

## What changed

- `defaults/main.yml` — new `django_use_uv`, `django_uv_version`, `django_uv_project_dir`, `django_uv_sync_args`.
- `tasks/python.yml` — installs the `uv` binary to `/usr/local/bin/uv` via the official astral.sh installer when the mode is enabled. Idempotent via `creates:`.
- `tasks/install.yml` — runs `uv sync` with `UV_PROJECT_ENVIRONMENT={{ django_venv_path }}`, `UV_LINK_MODE=copy`, `UV_COMPILE_BYTECODE=1`. Placed *before* the existing `django_pip_packages` task so extras (uwsgi, celery, …) install into the uv-created venv unchanged.
- `README.md` — documents the new mode and tunables.
- `molecule/uv/` — new molecule scenario with a tiny self-contained fixture project (`tests/fixtures/sample-uv-project/`) seeded as a local git repo by `prepare.yml`. testinfra checks: uv binary present, venv populated, `django-admin` exists, and a `django_pip_packages` extra (`click`) lands in the same venv — verifying the cohabitation that tally-ho relies on for uwsgi.

## Test plan

- [ ] `ansible-lint` clean (verified locally)
- [ ] `yamllint` clean (verified locally)
- [ ] CI `molecule test --all` exercises the new `uv` scenario on ubuntu2204
- [ ] Reviewer eyeballs the new install path for shell injection, idempotency, ownership semantics