### PR TITLE
feat: version-aware idempotent deploys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,8 +181,14 @@ django_celeryd_log_level: "INFO"
 django_celerybeat_log_level: "INFO"
 django_celeryd_pid_directory: "/run/celery-{{ django_system_user }}"
 django_celeryd_pid_file: "{{ django_celeryd_pid_directory }}/%n.pid"
-django_celery_beat_pid_directory: "/var/run/{{ django_system_user }}"
+# Beat's own runtime dir (matches its unit's RuntimeDirectory). Keeping the
+# pidfile out of the uwsgi unit's /run/<service> dir, which systemd wipes on
+# every uwsgi restart.
+django_celery_beat_pid_directory: "/run/celerybeat-{{ django_system_user }}"
 django_celery_beat_pid_file: "{{ django_celery_beat_pid_directory }}/celerybeat.pid"
 
 # Celery systemd service
 django_celeryd_timeoutsec: 100
+# Stop timeout for the celery worker unit: long enough to drain typical
+# tasks, finite so a wedged worker cannot stall deploy restarts forever.
+django_celeryd_stop_timeoutsec: 360

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,8 @@ django_celerybeat_extra_env_vars: []
 # Python packages
 django_install_virtualenv: true
 django_recreate_virtual_env: false
+# Force a full redeploy even when the desired version is already live
+django_force_deploy: false
 django_setuptools_version:
 
 ## pipenv

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,6 +26,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - verify
     - cleanup
     - destroy

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,6 +16,12 @@ platforms:
       LANG: "C.UTF-8"
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      # Resolve the role under test from this checkout, not from a
+      # galaxy-installed copy in ~/.ansible/roles.
+      roles_path: >-
+        ${MOLECULE_PROJECT_DIRECTORY}/..:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 scenario:
   name: default
   test_sequence:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -41,3 +41,12 @@ def test_local_settings(host):
     assert local_settings.user == "django_example_app"
     assert local_settings.group == "www-data"
     assert local_settings.mode == 0o644
+
+
+def test_versioned_release_marker(host):
+    app = host.file("/home/django_example_app/app")
+    assert app.is_symlink
+
+    marker = host.file("/home/django_example_app/app/.deployed_version")
+    assert marker.exists
+    assert len(marker.content_string.strip()) == 40

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -5,7 +5,7 @@
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     path: "{{ item }}"
-    mode: "0644"
+    mode: "0755"
   when:
     - item is defined
     - item is not none

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,6 +2,7 @@
 - name: Get previous app deploy listing
   command: ls -tr1 chdir={{ django_versioned_path }}
   register: versioned_list
+  changed_when: false
   tags:
     - skip_ansible_lint
 
@@ -9,5 +10,5 @@
   ansible.builtin.file:
     path: "{{ django_versioned_path }}/{{ versioned_list.stdout_lines[item | int] }}"
     state: absent
-  with_sequence: start=0 end={{ versioned_list.stdout_lines | length - 10 if versioned_list.stdout_lines | length > 10 else 1 }}
-  when: versioned_list.stdout_lines | int > 10
+  with_sequence: start=0 end={{ versioned_list.stdout_lines | length - 11 if versioned_list.stdout_lines | length > 10 else 0 }}
+  when: versioned_list.stdout_lines | length > 10

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,12 @@
 ---
+# Tag-scoped runs (e.g. --tags config) skip install.yml, which normally
+# resolves the desired version and release paths. Re-run the version check
+# here when its facts are missing so configure tasks target the live release
+# instead of failing on undefined variables.
+- name: Determine whether a deploy is needed (config-scoped runs)
+  ansible.builtin.include_tasks: version_check.yml
+  when: django_desired_sha is not defined
+
 - name: Run Django init commands
   django_manage:
     command: "{{ item }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Run Django init commands
   django_manage:
     command: "{{ item }}"
-    app_path: "{{ django_checkout_path }}"
+    app_path: "{{ django_release_path }}"
     virtualenv: "{{ django_venv_path }}"
   with_items: "{{ django_init_commands }}"
   become: true
@@ -13,7 +13,7 @@
 
 - name: Make sure the static folder exists
   ansible.builtin.file:
-    path: "{{ django_static_path }}"
+    path: "{{ django_effective_static_path }}"
     state: directory
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
@@ -33,9 +33,18 @@
     - django_media_path is defined
     - django_media_path is not none
 
+- name: Record the deployed version
+  ansible.builtin.copy:
+    content: "{{ django_desired_sha }}\n"
+    dest: "{{ django_release_path }}/.deployed_version"
+    owner: "{{ django_system_user }}"
+    group: "{{ django_system_group }}"
+    mode: "0644"
+  become: true
+
 - name: Make the new codebase current
   ansible.builtin.file:
-    src: "{{ django_checkout_path }}"
+    src: "{{ django_release_path }}"
     dest: "{{ django_codebase_path }}"
     state: link
     force: true
@@ -51,7 +60,7 @@
 - name: Copy uwsgi.ini
   ansible.builtin.template:
     src: uwsgi.ini.j2
-    dest: "{{ django_checkout_path }}/uwsgi.ini"
+    dest: "{{ django_release_path }}/uwsgi.ini"
     mode: "0644"
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,10 +11,6 @@
     append: true
     createhome: true
 
-- name: Update apt cache
-  ansible.builtin.apt:
-    update_cache: "yes"
-
 - name: Install system-wide dependencies
   ansible.builtin.apt:
     name: "{{ django_system_wide_dependencies }}"
@@ -177,7 +173,7 @@
 - name: Install Poetry
   ansible.builtin.command:
     cmd: "{{ django_python_version }} /tmp/install-poetry.py"
-    creates: /tmp/install-poetry.py
+    creates: "{{ django_system_user_home }}/.local/bin/poetry"
   become: true
   become_user: "{{ django_system_user }}"
   environment:
@@ -187,7 +183,7 @@
 
 - name: Disable poetry virtualenv
   ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.create false"
-  changed_when: true
+  changed_when: false
   become: true
   become_user: "{{ django_system_user }}"
   when:
@@ -195,7 +191,7 @@
 
 - name: Set poetry virtualenv
   ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.path {{ django_system_user_home }}/.virtualenvs/"
-  changed_when: true
+  changed_when: false
   become: true
   become_user: "{{ django_system_user }}"
   when:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,14 +18,6 @@
     update_cache: true
     cache_valid_time: 600
 
-- name: Delete virtualenv
-  ansible.builtin.file:
-    state: absent
-    path: "{{ item }}"
-  with_items:
-    - "{{ django_venv_path }}"
-  when: django_recreate_virtual_env
-
 - name: Ensure required directories are present
   ansible.builtin.file:
     state: directory
@@ -65,21 +57,6 @@
     - django_git_key_ssh_file is defined
     - django_git_key_ssh_file is not none
 
-- name: Git clone with key
-  ansible.builtin.git:
-    accept_hostkey: "yes"
-    repo: "{{ django_git_url }}"
-    dest: "{{ django_checkout_path }}"
-    version: "{{ django_git_version }}"
-    depth: "1"
-    key_file: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
-    force: true
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_git_key_content is defined or django_git_key_ssh_file is defined
-    - django_git_key_content is not none or django_git_key_ssh_file is not none
-
 - name: Ensure Github is in the known hosts file
   ansible.builtin.known_hosts:
     path: "{{ django_system_user_home }}/.ssh/known_hosts"
@@ -89,192 +66,229 @@
     - django_git_key_content is defined or django_git_key_ssh_file is defined
     - django_git_key_content is not none or django_git_key_ssh_file is not none
 
-- name: Git clone without key
-  ansible.builtin.git:
-    accept_hostkey: "yes"
-    repo: "{{ django_git_url }}"
-    dest: "{{ django_checkout_path }}"
-    version: "{{ django_git_version }}"
-    depth: "1"
-    force: true
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_git_key_content is not defined or django_git_key_content is none
-    - django_git_key_ssh_file is not defined or django_git_key_ssh_file is none
+- name: Determine whether a deploy is needed
+  ansible.builtin.include_tasks: version_check.yml
 
-- name: Upgrade setuptools to desired version
-  ansible.builtin.pip:
-    name: setuptools
-    version: "{{ django_setuptools_version }}"
-    state: present
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-  become: true
-  become_user: "{{ django_system_user }}"
-  when: django_setuptools_version is defined and django_setuptools_version is not none and django_setuptools_version | length > 0
+- name: Deploy the application
+  when: django_deploy_needed | bool
+  block:
+    - name: Delete virtualenv
+      ansible.builtin.file:
+        state: absent
+        path: "{{ item }}"
+      with_items:
+        - "{{ django_venv_path }}"
+      when: django_recreate_virtual_env
 
-- name: Install dependency Python packages using pip
-  ansible.builtin.pip:
-    name: "{{ django_dependency_pip_packages }}"
-    state: present
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-  become: true
-  become_user: "{{ django_system_user }}"
-  when: django_dependency_pip_packages | length > 0
+    - name: Ensure the virtualenv directory is present
+      ansible.builtin.file:
+        state: directory
+        owner: "{{ django_system_user }}"
+        group: "{{ django_system_group }}"
+        path: "{{ django_venv_path }}"
+        mode: "0755"
 
-- name: Install a custom pip version
-  ansible.builtin.pip:
-    name: "{{ custom_pip_version }}"
-    virtualenv: "{{ django_venv_path }}"
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - custom_pip_version is defined and custom_pip_version != ""
+    - name: Git clone with key
+      ansible.builtin.git:
+        accept_hostkey: "yes"
+        repo: "{{ django_git_url }}"
+        dest: "{{ django_release_path }}"
+        version: "{{ django_git_version }}"
+        depth: "1"
+        key_file: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
+        force: true
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_git_key_content is defined or django_git_key_ssh_file is defined
+        - django_git_key_content is not none or django_git_key_ssh_file is not none
 
-- name: Install Python packages using pip
-  ansible.builtin.pip:
-    state: present
-    requirements: "{{ item }}"
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-  become: true
-  become_user: "{{ django_system_user }}"
-  with_items: "{{ django_pip_paths }}"
-  environment:
-    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
-  when:
-    - django_use_regular_old_pip| bool
+    - name: Git clone without key
+      ansible.builtin.git:
+        accept_hostkey: "yes"
+        repo: "{{ django_git_url }}"
+        dest: "{{ django_release_path }}"
+        version: "{{ django_git_version }}"
+        depth: "1"
+        force: true
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_git_key_content is not defined or django_git_key_content is none
+        - django_git_key_ssh_file is not defined or django_git_key_ssh_file is none
 
-- name: Install pipenv
-  ansible.builtin.pip:
-    name: pipenv
-    state: present
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-  become: true
-  become_user: "{{ django_system_user }}"
-  environment:
-    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
-  when:
-    - django_use_pipenv| bool
+    - name: Upgrade setuptools to desired version
+      ansible.builtin.pip:
+        name: setuptools
+        version: "{{ django_setuptools_version }}"
+        state: present
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+      when: django_setuptools_version is defined and django_setuptools_version is not none and django_setuptools_version | length > 0
 
-- name: Download Poetry
-  ansible.builtin.get_url:
-    url: "https://install.python-poetry.org"
-    dest: /tmp/install-poetry.py
-    mode: "0644"
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_use_poetry| bool
+    - name: Install dependency Python packages using pip
+      ansible.builtin.pip:
+        name: "{{ django_dependency_pip_packages }}"
+        state: present
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+      when: django_dependency_pip_packages | length > 0
 
-- name: Install Poetry
-  ansible.builtin.command:
-    cmd: "{{ django_python_version }} /tmp/install-poetry.py"
-    creates: "{{ django_system_user_home }}/.local/bin/poetry"
-  become: true
-  become_user: "{{ django_system_user }}"
-  environment:
-    PATH: "{{ ansible_env.PATH }}:{{ django_system_user }}/.local/bin"
-  when:
-    - django_use_poetry| bool
+    - name: Install a custom pip version
+      ansible.builtin.pip:
+        name: "{{ custom_pip_version }}"
+        virtualenv: "{{ django_venv_path }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - custom_pip_version is defined and custom_pip_version != ""
 
-- name: Disable poetry virtualenv
-  ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.create false"
-  changed_when: false
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_use_poetry| bool
+    - name: Install Python packages using pip
+      ansible.builtin.pip:
+        state: present
+        requirements: "{{ item }}"
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+      with_items: "{{ django_effective_pip_paths }}"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
+      when:
+        - django_use_regular_old_pip| bool
 
-- name: Set poetry virtualenv
-  ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.path {{ django_system_user_home }}/.virtualenvs/"
-  changed_when: false
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_use_poetry| bool
+    - name: Install pipenv
+      ansible.builtin.pip:
+        name: pipenv
+        state: present
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
+      when:
+        - django_use_pipenv| bool
 
-- name: Install requriements via poetry
-  ansible.builtin.shell: source {{ django_venv_path }}/bin/activate && {{ django_system_user_home }}/.local/bin/poetry install
-  changed_when: true
-  become: true
-  become_user: "{{ django_system_user }}"
-  args:
-    chdir: "{{ django_checkout_path }}"
-    executable: /bin/bash
-  when:
-    - django_use_poetry| bool
+    - name: Download Poetry
+      ansible.builtin.get_url:
+        url: "https://install.python-poetry.org"
+        dest: /tmp/install-poetry.py
+        mode: "0644"
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_use_poetry| bool
 
-- name: Install Python packages using pipenv
-  ansible.builtin.shell: source {{ django_venv_path }}/bin/activate && pipenv sync --python {{ django_python_version }}
-  changed_when: true
-  args:
-    chdir: "{{ django_checkout_path }}"
-    executable: /bin/bash
-  environment:
-    PIPENV_VERBOSITY: "-1"
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_use_pipenv| bool
+    - name: Install Poetry
+      ansible.builtin.command:
+        cmd: "{{ django_python_version }} /tmp/install-poetry.py"
+        creates: "{{ django_system_user_home }}/.local/bin/poetry"
+      become: true
+      become_user: "{{ django_system_user }}"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{ django_system_user }}/.local/bin"
+      when:
+        - django_use_poetry| bool
 
-- name: Install Python packages using uv sync
-  ansible.builtin.command:
-    cmd: >-
-      uv sync
-      {{ django_uv_sync_args }}
-      --python {{ django_python_version }}
-    chdir: "{{ django_uv_project_dir }}"
-  environment:
-    UV_PROJECT_ENVIRONMENT: "{{ django_venv_path }}"
-    UV_LINK_MODE: copy
-    UV_COMPILE_BYTECODE: "1"
-  become: true
-  become_user: "{{ django_system_user }}"
-  changed_when: true
-  when:
-    - django_use_uv| bool
+    - name: Disable poetry virtualenv
+      ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.create false"
+      changed_when: false
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_use_poetry| bool
 
-# uv sync does not install pip into the venv (uv manages packages
-# directly). Bootstrap pip so the mode-agnostic extras-pip step below
-# (django_pip_packages: uwsgi, celery, ...) has a working pip binary.
-- name: Bootstrap pip into the uv-managed venv
-  ansible.builtin.command:
-    cmd: >-
-      uv pip install
-      --python {{ django_venv_path }}/bin/python
-      pip
-    creates: "{{ django_venv_path }}/bin/pip"
-  environment:
-    UV_LINK_MODE: copy
-  become: true
-  become_user: "{{ django_system_user }}"
-  when:
-    - django_use_uv| bool
+    - name: Set poetry virtualenv
+      ansible.builtin.command: "{{ django_system_user_home }}/.local/bin/poetry config virtualenvs.path {{ django_system_user_home }}/.virtualenvs/"
+      changed_when: false
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_use_poetry| bool
 
-- name: Install other python packages using pip
-  ansible.builtin.pip:
-    name: "{{ django_pip_packages }}"
-    state: present
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-    extra_args: "{{ django_pip_packages_extra_args }}"
-  become: true
-  become_user: "{{ django_system_user }}"
+    - name: Install requriements via poetry
+      ansible.builtin.shell: source {{ django_venv_path }}/bin/activate && {{ django_system_user_home }}/.local/bin/poetry install
+      changed_when: true
+      become: true
+      become_user: "{{ django_system_user }}"
+      args:
+        chdir: "{{ django_release_path }}"
+        executable: /bin/bash
+      when:
+        - django_use_poetry| bool
 
-- name: Install packages from Github
-  become: true
-  become_user: "{{ django_system_user }}"
-  ansible.builtin.pip:
-    name: "{{ item }}"
-    virtualenv: "{{ django_venv_path }}"
-    virtualenv_python: "{{ django_python_version }}"
-    extra_args: "-e"
-  with_items: "{{ django_optional_git_packages }}"
-  when: django_optional_git_packages is defined and django_use_regular_old_pip
+    - name: Install Python packages using pipenv
+      ansible.builtin.shell: source {{ django_venv_path }}/bin/activate && pipenv sync --python {{ django_python_version }}
+      changed_when: true
+      args:
+        chdir: "{{ django_release_path }}"
+        executable: /bin/bash
+      environment:
+        PIPENV_VERBOSITY: "-1"
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_use_pipenv| bool
+
+    - name: Install Python packages using uv sync
+      ansible.builtin.command:
+        cmd: >-
+          uv sync
+          {{ django_uv_sync_args }}
+          --python {{ django_python_version }}
+        chdir: "{{ django_uv_project_dir | replace(django_checkout_path, django_release_path) }}"
+      environment:
+        UV_PROJECT_ENVIRONMENT: "{{ django_venv_path }}"
+        UV_LINK_MODE: copy
+        UV_COMPILE_BYTECODE: "1"
+      become: true
+      become_user: "{{ django_system_user }}"
+      changed_when: true
+      when:
+        - django_use_uv| bool
+
+    # uv sync does not install pip into the venv (uv manages packages
+    # directly). Bootstrap pip so the mode-agnostic extras-pip step below
+    # (django_pip_packages: uwsgi, celery, ...) has a working pip binary.
+    - name: Bootstrap pip into the uv-managed venv
+      ansible.builtin.command:
+        cmd: >-
+          uv pip install
+          --python {{ django_venv_path }}/bin/python
+          pip
+        creates: "{{ django_venv_path }}/bin/pip"
+      environment:
+        UV_LINK_MODE: copy
+      become: true
+      become_user: "{{ django_system_user }}"
+      when:
+        - django_use_uv| bool
+
+    - name: Install other python packages using pip
+      ansible.builtin.pip:
+        name: "{{ django_pip_packages }}"
+        state: present
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+        extra_args: "{{ django_pip_packages_extra_args }}"
+      become: true
+      become_user: "{{ django_system_user }}"
+
+    - name: Install packages from Github
+      become: true
+      become_user: "{{ django_system_user }}"
+      ansible.builtin.pip:
+        name: "{{ item }}"
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_python: "{{ django_python_version }}"
+        extra_args: "-e"
+      with_items: "{{ django_optional_git_packages }}"
+      when: django_optional_git_packages is defined and django_use_regular_old_pip
 
 - name: Remove Git Key
   ansible.builtin.file:
@@ -289,7 +303,7 @@
 
 - name: Make sure the local settings directory is present
   ansible.builtin.file:
-    path: "{{ django_local_settings_path | dirname }}"
+    path: "{{ django_effective_local_settings_path | dirname }}"
     state: directory
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
@@ -298,7 +312,7 @@
 - name: Copy local settings from template
   ansible.builtin.template:
     src: "{{ django_settings_template_path }}"
-    dest: "{{ django_local_settings_path }}"
+    dest: "{{ django_effective_local_settings_path }}"
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     mode: "0644"
@@ -306,7 +320,7 @@
 - name: Copy the environment script
   ansible.builtin.template:
     src: "django_checkout_path/django_environment_script_name.j2"
-    dest: "{{ django_checkout_path }}/{{ django_environment_script_name }}"
+    dest: "{{ django_release_path }}/{{ django_environment_script_name }}"
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     mode: "0750"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,6 +35,10 @@
     - "{{ django_log_path }}"
     - "{{ django_system_user_home }}/.ssh"
 
+# The git key tasks (copy here, removal at the end of this file) run for
+# real even under --check: the version check's ls-remote needs a working key
+# on the host to evaluate state, and the removal guarantees check runs clean
+# up after themselves just like real runs.
 - name: Copy git key from string
   ansible.builtin.copy:
     content: "{{ django_git_key_content }}"
@@ -42,6 +46,7 @@
     owner: "{{ django_system_user }}"
     mode: "0600"
   no_log: false
+  check_mode: false
   when:
     - django_git_key_content is defined
     - django_git_key_content is not none
@@ -53,6 +58,7 @@
     owner: "{{ django_system_user }}"
     mode: "0600"
   no_log: false
+  check_mode: false
   when:
     - django_git_key_ssh_file is defined
     - django_git_key_ssh_file is not none
@@ -299,6 +305,8 @@
     path: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
   become: true
   become_user: "{{ django_system_user }}"
+  # Real removal in --check too, so check runs clean up the key they copied.
+  check_mode: false
   when:
     - django_git_key_content is defined or django_git_key_ssh_file is defined
     - django_git_key_content is not none or django_git_key_ssh_file is not none

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,7 +45,7 @@
     dest: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
     owner: "{{ django_system_user }}"
     mode: "0600"
-  no_log: false
+  no_log: true
   check_mode: false
   when:
     - django_git_key_content is defined
@@ -57,7 +57,7 @@
     dest: "{{ django_system_user_home }}/.ssh/{{ django_git_key_filename }}"
     owner: "{{ django_system_user }}"
     mode: "0600"
-  no_log: false
+  no_log: true
   check_mode: false
   when:
     - django_git_key_ssh_file is defined
@@ -327,6 +327,8 @@
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     mode: "0644"
+  # Rendered settings contain credentials; never print them under --diff.
+  diff: false
 
 - name: Copy the environment script
   ansible.builtin.template:
@@ -335,3 +337,5 @@
     owner: "{{ django_system_user }}"
     group: "{{ django_system_group }}"
     mode: "0750"
+  # Environment scripts can carry secrets; keep them out of --diff output.
+  diff: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -61,7 +61,10 @@
   ansible.builtin.known_hosts:
     path: "{{ django_system_user_home }}/.ssh/known_hosts"
     name: github.com
-    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+    # Strip ssh-keyscan's "# host:port banner" comment lines: the banner
+    # varies per frontend, and including it makes the entry never match the
+    # file, so the task would report changed on every run.
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com 2>/dev/null | grep -v \"^#\"') }}"
   when:
     - django_git_key_content is defined or django_git_key_ssh_file is defined
     - django_git_key_content is not none or django_git_key_ssh_file is not none

--- a/tasks/version_check.yml
+++ b/tasks/version_check.yml
@@ -1,0 +1,74 @@
+---
+- name: Resolve the desired git version to a commit SHA
+  ansible.builtin.shell: |
+    set -o pipefail
+    git ls-remote {{ django_git_url | quote }} \
+      "refs/heads/{{ django_git_version }}" \
+      "refs/tags/{{ django_git_version }}" \
+      "refs/tags/{{ django_git_version }}^{}" \
+      | tail -n1 | cut -f1
+  args:
+    executable: /bin/bash
+  environment:
+    GIT_SSH_COMMAND: >-
+      ssh -o StrictHostKeyChecking=accept-new{{ ' -i ' + django_system_user_home + '/.ssh/' + django_git_key_filename
+         if (django_git_key_content or django_git_key_ssh_file) else '' }}
+  register: django_ls_remote
+  changed_when: false
+  check_mode: false
+  become: true
+  become_user: "{{ django_system_user }}"
+
+- name: Set the desired deploy SHA
+  ansible.builtin.set_fact:
+    django_desired_sha: >-
+      {{ django_ls_remote.stdout | trim
+         if (django_ls_remote.stdout | trim | length) > 0
+         else django_git_version }}
+
+- name: Fail when the desired version cannot be resolved
+  ansible.builtin.fail:
+    msg: "Could not resolve version '{{ django_git_version }}' at {{ django_git_url }} to a commit SHA"
+  when: not (django_desired_sha is match('^[0-9a-f]{40}$'))
+
+- name: Check the current codebase link
+  ansible.builtin.stat:
+    path: "{{ django_codebase_path }}"
+  register: django_codebase_link
+
+- name: Read the deployed version marker
+  ansible.builtin.slurp:
+    src: "{{ django_codebase_path }}/.deployed_version"
+  register: django_version_marker
+  failed_when: false
+  when: django_codebase_link.stat.islnk | default(false)
+
+- name: Decide whether a deploy is needed
+  ansible.builtin.set_fact:
+    django_deploy_needed: >-
+      {{ django_force_deploy | bool
+         or django_recreate_virtual_env | bool
+         or not (django_codebase_link.stat.islnk | default(false))
+         or django_version_marker.content is not defined
+         or (django_version_marker.content | b64decode | trim) != django_desired_sha }}
+
+- name: Use the current release directory for this run
+  ansible.builtin.set_fact:
+    django_release_path: "{{ django_codebase_link.stat.lnk_source }}"
+  when: not (django_deploy_needed | bool)
+
+- name: Use a new release directory for this run
+  ansible.builtin.set_fact:
+    django_release_path: "{{ django_checkout_path }}"
+  when: django_deploy_needed | bool
+
+- name: Compute effective release paths
+  ansible.builtin.set_fact:
+    django_effective_local_settings_path: >-
+      {{ (django_local_settings_path | replace(django_checkout_path, django_release_path))
+         if django_local_settings_path else django_local_settings_path }}
+    django_effective_static_path: >-
+      {{ (django_static_path | replace(django_checkout_path, django_release_path))
+         if django_static_path else django_static_path }}
+    django_effective_pip_paths: >-
+      {{ django_pip_paths | map('replace', django_checkout_path, django_release_path) | list }}

--- a/templates/etc/systemd/celerybeat.service.j2
+++ b/templates/etc/systemd/celerybeat.service.j2
@@ -8,7 +8,9 @@ User={{ django_system_user }}
 Group={{ django_system_group }}
 EnvironmentFile=-/etc/default/celerybeat-{{ django_system_user }}
 WorkingDirectory={{ django_codebase_path }}
-RuntimeDirectory=celery-{{ django_system_user }}
+# Own runtime dir: sharing celeryd's would let this unit's stop/start wipe
+# the worker pidfiles (systemd removes a RuntimeDirectory on unit stop).
+RuntimeDirectory=celerybeat-{{ django_system_user }}
 ExecStart=/bin/sh -c '${CELERY_BIN} -A $CELERY_APP \
     --workdir={{ django_codebase_path }} beat \
     --pidfile=${CELERYBEAT_PID_FILE} \

--- a/templates/etc/systemd/celeryd.service.j2
+++ b/templates/etc/systemd/celeryd.service.j2
@@ -10,6 +10,10 @@ EnvironmentFile=-/etc/default/celeryd-{{ django_system_user }}
 WorkingDirectory={{ django_codebase_path }}
 RuntimeDirectory=celery-{{ django_system_user }}
 TimeoutStartSec={{ django_celeryd_timeoutsec }}
+# Give `celery multi stopwait` time to drain tasks; on expiry systemd
+# SIGKILLs the whole cgroup so no old master survives into the next start
+# and deletes the fresh pidfiles.
+TimeoutStopSec={{ django_celeryd_stop_timeoutsec }}
 ExecStart=/bin/sh -c '${CELERY_BIN} -A $CELERY_APP multi start $CELERYD_NODES \
     --logfile=${CELERYD_LOG_FILE} \
     --loglevel="${CELERYD_LOG_LEVEL}" \

--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -13,8 +13,8 @@ master={{ django_wsgi_master }}
 processes={{ django_wsgi_processes }}
 pidfile={{ django_pid_file }}
 vacuum={{ django_wsgi_vacuum }}                # clear environment on exit
-harakiri={{ django_wsgi_harakiri }}            # respawn processes taking more than 240 seconds
-max-requests={{ django_wsgi_max_requests }}    # respawn processes after serving 5000 requests
+harakiri={{ django_wsgi_harakiri }}            # respawn processes taking more than this many seconds
+max-requests={{ django_wsgi_max_requests }}    # respawn processes after serving this many requests
 logto={{ django_wsgi_logto }}
 virtualenv={{ django_wsgi_virtualenv }}
 {% if django_wsgi_use_cheaper %}

--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -31,7 +31,9 @@ cheaper-step={{ django_wsgi_cheaper_spawn_rate }}
 cheaper-overload={{ django_wsgi_cheaper_overload }}
 {% endif %}
 {% if django_wsgi_static_map %}
-static-map={{ django_wsgi_static_map }}
+{# Rewrite any per-run checkout prefix to the effective release directory so
+   the rendered config is stable (and correct) on runs that skip the deploy. #}
+static-map={{ django_wsgi_static_map | replace(django_checkout_path, django_release_path) }}
 {% endif %}
 buffer-size={{ django_wsgi_buffer_size }}
 {% if django_wsgi_env %}


### PR DESCRIPTION
## Summary
- Resolve the desired git version to a commit SHA (`git ls-remote`) and skip the entire deploy block (clone/venv/pip/poetry/pipenv/uv) when it matches the `.deployed_version` marker of the release the codebase symlink points to. Same-version reruns are now no-ops; molecule's `idempotence` step enforces `changed=0`.
- New `django_force_deploy` var forces a redeploy; `django_recreate_virtual_env: true` also implies one.
- Fix always-changed/latently-broken tasks:
  - bare `Update apt cache` task removed (next task already updates with `cache_valid_time`)
  - poetry installer `creates:` pointed at the installer script it had just downloaded, so poetry never actually installed — now points at the poetry binary
  - `poetry config` tasks and the cleanup `ls` no longer report changed
  - celery pid directories used file mode `0644`; now `0755`
  - cleanup guard compared a list with `| int` (always 0) so the keep-last-10 purge never ran; now guards on `| length` and deletes exactly the oldest beyond 10
- `uwsgi.ini` static-map keeps pointing at the live release on skip runs (previously each rerun rendered a fresh, nonexistent epoch path).
- Molecule resolves the role under test from the checkout instead of a stale `~/.ansible/roles` copy; testinfra asserts the release marker.

## Rollout notes (one-time effects on existing hosts)
- First run after upgrade behaves exactly like a normal full deploy and writes the marker; idempotent skips start from the second run.
- Hosts with >10 accumulated release dirs get purged down to the 10 newest in one run (the old guard was inert).
- Hosts with `django_use_poetry: true` will install poetry for the first time.
- pip/venv package changes now only apply on a version change or `django_force_deploy: true`.
- With git keys + `django_remove_git_key: true`, the key copy still reports changed each run (pre-existing, accepted).

## Test plan
- [x] `molecule test` (ubuntu2204): fresh converge, idempotence rerun `changed=0`, testinfra 6/6 (incl. new `.deployed_version` marker check)
- [x] Consumed by onaio/ansible-onadata molecule end-to-end (its PR pins this branch until merge)
- [ ] Staging: first run full-deploys, second run reports ~0 changes

Note: CI on `main` has been red since 2026-06-08 (ansible-lint strictness drift + runner docker issues) — unrelated to this branch.